### PR TITLE
Cargo features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ codegen-units = 1   # Reduce number of codegen units to increase optimizations
 strip = true        # Strip symbols from binary*
 
 [workspace]
+resolver = "2"
 default-members = [
     "rustmath",
 ]

--- a/rustmath/Cargo.toml
+++ b/rustmath/Cargo.toml
@@ -5,10 +5,14 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["png"]
+png = ["dep:png", "tiny-skia"]
+
 [dependencies]
 nom = "7.1.3"
-png = "0.17.9"
-tiny-skia = { version = "0.11.0", default-features = false, features=["std"] }
+png = { version = "0.17.9", optional = true }
+tiny-skia = { version = "0.11.0", default-features = false, features=["std"], optional = true }
 ttf-parser = "0.19.0"
 
 [dev-dependencies]

--- a/rustmath/Cargo.toml
+++ b/rustmath/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["png", "svg"]
+default = ["embedded-font", "png", "svg"]
+embedded-font = []
 png = ["dep:png", "tiny-skia"]
 svg = []
 

--- a/rustmath/Cargo.toml
+++ b/rustmath/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["png"]
+default = ["png", "svg"]
 png = ["dep:png", "tiny-skia"]
+svg = []
 
 [dependencies]
 nom = "7.1.3"

--- a/rustmath/src/backend.rs
+++ b/rustmath/src/backend.rs
@@ -1,3 +1,5 @@
 pub mod opentype;
+
+#[cfg(feature = "tiny-skia")]
 pub mod raster;
 pub mod svg;

--- a/rustmath/src/backend.rs
+++ b/rustmath/src/backend.rs
@@ -2,4 +2,6 @@ pub mod opentype;
 
 #[cfg(feature = "tiny-skia")]
 pub mod raster;
+
+#[cfg(feature = "svg")]
 pub mod svg;

--- a/rustmath/src/backend/opentype.rs
+++ b/rustmath/src/backend/opentype.rs
@@ -391,15 +391,21 @@ impl<'a, R: OpenTypeRenderer> common::FontBackend for FontBackend<'a, R> {
     }
 }
 
-impl<R: OpenTypeRenderer> Default for FontBackend<'static, R> {
-    fn default() -> Self {
-        let face =
-            ttf_parser::Face::parse(include_bytes!("../../data/NewCMMath-Regular.otf"), 0).unwrap();
+impl<'a, R: OpenTypeRenderer> FontBackend<'a, R> {
+    pub fn new_from_font_data(data: &'a [u8]) -> Option<Self> {
+        let face = ttf_parser::Face::parse(data, 0).ok()?;
         let font = Font {
             face,
             _phantom: Default::default(),
         };
-        Self { font }
+        Some(Self { font })
+    }
+}
+
+#[cfg(feature = "embedded-font")]
+impl<R: OpenTypeRenderer> Default for FontBackend<'static, R> {
+    fn default() -> Self {
+        Self::new_from_font_data(include_bytes!("../../data/NewCMMath-Regular.otf")).unwrap()
     }
 }
 

--- a/rustmath/src/lib.rs
+++ b/rustmath/src/lib.rs
@@ -153,10 +153,10 @@ fn get_source_from_svg_metadata(png: &[u8]) -> Option<String> {
     rustmath_source
 }
 
-pub fn get_source_from_metadata(data: &[u8]) -> Option<String> {
+pub fn get_source_from_metadata(_data: &[u8]) -> Option<String> {
     #[cfg(feature = "png")]
     {
-        let result = get_source_from_png_metadata(data);
+        let result = get_source_from_png_metadata(_data);
         if result.is_some() {
             return result;
         }
@@ -164,7 +164,7 @@ pub fn get_source_from_metadata(data: &[u8]) -> Option<String> {
 
     #[cfg(feature = "svg")]
     {
-        let result = get_source_from_svg_metadata(data);
+        let result = get_source_from_svg_metadata(_data);
         if result.is_some() {
             return result;
         }

--- a/rustmath/src/lib.rs
+++ b/rustmath/src/lib.rs
@@ -1,4 +1,3 @@
-use backend::raster::TinySkiaRenderer;
 use backend::svg::SvgRenderer;
 
 pub mod backend;
@@ -27,7 +26,10 @@ pub fn render_layout<R: backend::opentype::OpenTypeRenderer>(
     Some(canvas.finish())
 }
 
+#[cfg(feature = "tiny-skia")]
 pub fn render_string(src: &str) -> Option<tiny_skia::Pixmap> {
+    use backend::raster::TinySkiaRenderer;
+
     let list = parser::parse(src)?;
 
     let fb = backend::opentype::FontBackend::<TinySkiaRenderer>::default();
@@ -36,6 +38,7 @@ pub fn render_string(src: &str) -> Option<tiny_skia::Pixmap> {
     render_layout(fb, node)
 }
 
+#[cfg(feature = "png")]
 pub fn encode_png(src: &str, include_meta_data: bool) -> Option<Vec<u8>> {
     let pixmap = render_string(src)?;
 
@@ -70,6 +73,7 @@ pub fn encode_png(src: &str, include_meta_data: bool) -> Option<Vec<u8>> {
     Some(result)
 }
 
+#[cfg(feature = "png")]
 fn get_source_from_png_metadata(png: &[u8]) -> Option<String> {
     if !png.starts_with(b"\x89PNG") {
         return None;
@@ -98,6 +102,7 @@ fn get_source_from_png_metadata(png: &[u8]) -> Option<String> {
     rustmath_source
 }
 
+#[cfg(feature = "png")]
 pub fn save_png(src: &str, include_meta_data: bool, filename: &str) {
     let data = encode_png(src, include_meta_data).unwrap();
     std::fs::write(filename, data).unwrap();
@@ -147,9 +152,12 @@ fn get_source_from_svg_metadata(png: &[u8]) -> Option<String> {
 }
 
 pub fn get_source_from_metadata(data: &[u8]) -> Option<String> {
-    let result = get_source_from_png_metadata(data);
-    if result.is_some() {
-        return result;
+    #[cfg(feature = "png")]
+    {
+        let result = get_source_from_png_metadata(data);
+        if result.is_some() {
+            return result;
+        }
     }
 
     get_source_from_svg_metadata(data)

--- a/rustmath/src/lib.rs
+++ b/rustmath/src/lib.rs
@@ -1,5 +1,3 @@
-use backend::svg::SvgRenderer;
-
 pub mod backend;
 pub mod common;
 pub mod layout;
@@ -108,7 +106,10 @@ pub fn save_png(src: &str, include_meta_data: bool, filename: &str) {
     std::fs::write(filename, data).unwrap();
 }
 
+#[cfg(feature = "svg")]
 pub fn render_svg(src: &str, include_meta_data: bool) -> Option<String> {
+    use backend::svg::SvgRenderer;
+
     let list = parser::parse(src)?;
 
     let fb = backend::opentype::FontBackend::<SvgRenderer>::default();
@@ -127,6 +128,7 @@ pub fn render_svg(src: &str, include_meta_data: bool) -> Option<String> {
     Some(result)
 }
 
+#[cfg(feature = "svg")]
 fn get_source_from_svg_metadata(png: &[u8]) -> Option<String> {
     let s = core::str::from_utf8(png).ok()?;
     let metadata = backend::svg::parse_metadata(s)?;
@@ -160,5 +162,13 @@ pub fn get_source_from_metadata(data: &[u8]) -> Option<String> {
         }
     }
 
-    get_source_from_svg_metadata(data)
+    #[cfg(feature = "svg")]
+    {
+        let result = get_source_from_svg_metadata(data);
+        if result.is_some() {
+            return result;
+        }
+    }
+
+    None
 }

--- a/rustmath/src/main.rs
+++ b/rustmath/src/main.rs
@@ -1,4 +1,7 @@
 fn main() {
-    let src = "\\int\\sum x+\\mathop{log}y=2\\mitalpha";
-    rustmath::save_png(src, true, "image.png");
+    #[cfg(feature = "png")]
+    {
+        let src = "\\int\\sum x+\\mathop{log}y=2\\mitalpha";
+        rustmath::save_png(src, true, "image.png");
+    }
 }

--- a/rustmath/src/tests.rs
+++ b/rustmath/src/tests.rs
@@ -1,2 +1,4 @@
 mod test_generated_sources;
+
+#[cfg(feature = "png")]
 mod test_images;


### PR DESCRIPTION
This PR makes some dependencies optional; this can be used, for example, to reduce the bundle size in case not all features are needed:
* PNG rasterizer
* SVG renderer
* Embedded font